### PR TITLE
Fix iOS crash when PDF has an empty page

### DIFF
--- a/ios/Classes/SwiftReadPdfTextPlugin.swift
+++ b/ios/Classes/SwiftReadPdfTextPlugin.swift
@@ -43,7 +43,7 @@ public class SwiftReadPdfTextPlugin: NSObject, FlutterPlugin {
             let pageCount = pdf.pageCount
           
               for i in 0 ..< pageCount {
-                  let pageContent = pdf.page(at: i)!.string!
+                  let pageContent = pdf.page(at: i)?.string ?? ""
                   pdfText += pageContent
               }
                 DispatchQueue.main.sync {
@@ -68,7 +68,7 @@ private func getPDFtextPaginated (result: FlutterResult, path: String)
             let pageCount = pdf.pageCount
           
               for i in 0 ..< pageCount {
-                  let pageContent = pdf.page(at: i)!.string!
+                  let pageContent = pdf.page(at: i)?.string ?? ""
                   pdfArray.append(pageContent)
               }
                 DispatchQueue.main.sync {


### PR DESCRIPTION
Hi, thanks for creating this flutter plugin, it really helps. While using this plugin in my app, I noticed there has a crash issue on iOS device when PDF file contains empty page. Please review this PR or fix the issue on your prefer. Thanks again for making this plugin.